### PR TITLE
Fix missing $db when session write on exit

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -206,7 +206,6 @@ if (!function_exists('killme')) {
 	function killme()
 	{
 		session_write_close();
-		closedb();
 		exit;
 	}
 }

--- a/include/dba.php
+++ b/include/dba.php
@@ -165,9 +165,3 @@ function dbesc_array(&$arr)
 		array_walk($arr, 'dbesc_array_cb');
 	}
 }
-
-function closedb()
-{
-	global $db;
-	//	$db->close();
-}

--- a/include/dba.php
+++ b/include/dba.php
@@ -16,7 +16,8 @@ class dba
 	public function __construct($server, $user, $pass, $db, $install = false)
 	{
 		$this->db = @new mysqli($server, $user, $pass, $db);
-		if ((mysqli_connect_errno()) && (! install)) {
+
+		if (mysqli_connect_errno() && ! $install) {
 			system_unavailable();
 		}
 	}
@@ -40,7 +41,7 @@ class dba
 			$mesg = '';
 
 			if ($this->db->mysqli->errno) {
-				$debug_text .=  $this->db->mysqli->error . EOL;
+				$debug_text .= $this->db->mysqli->error . EOL;
 			}
 
 			if ($result === false) {
@@ -48,19 +49,19 @@ class dba
 			} elseif ($result === true) {
 				$mesg = 'true';
 			} else {
-				$mesg = $result->num_rows.' results' . EOL;
+				$mesg = $result->num_rows . ' results' . EOL;
 			}
 
-			$str =  'SQL = ' . printable($sql) . EOL . 'SQL returned ' . $mesg . EOL;
+			$str = 'SQL = ' . printable($sql) . EOL . 'SQL returned ' . $mesg . EOL;
 
 			switch ($this->debug) {
-			case 3:
-				echo $str;
-				break;
-			default:
-				$debug_text .= $str;
-				break;
-		}
+				case 3:
+					echo $str;
+					break;
+				default:
+					$debug_text .= $str;
+					break;
+			}
 		}
 
 		if (($result === true) || ($result === false)) {
@@ -76,9 +77,9 @@ class dba
 		}
 
 		if ($this->debug == 2) {
-			$debug_text .= printable(print_r($r, true). EOL);
+			$debug_text .= printable(print_r($r, true) . EOL);
 		} elseif ($this->debug == 3) {
-			echo printable(print_r($r, true) . EOL) ;
+			echo printable(print_r($r, true) . EOL);
 		}
 
 		return $r;
@@ -100,93 +101,73 @@ class dba
 	}
 }
 
-if (! function_exists('printable')) {
-	function printable($s)
-	{
-		$s = preg_replace("~([\x01-\x08\x0E-\x0F\x10-\x1F\x7F-\xFF])~", ".", $s);
-		$s = str_replace("\x00", '.', $s);
-		if (x($_SERVER, 'SERVER_NAME')) {
-			$s = escape_tags($s);
-		}
-		return $s;
+function printable($s)
+{
+	$s = preg_replace("~([\x01-\x08\x0E-\x0F\x10-\x1F\x7F-\xFF])~", ".", $s);
+	$s = str_replace("\x00", '.', $s);
+	if (x($_SERVER, 'SERVER_NAME')) {
+		$s = escape_tags($s);
 	}
+	return $s;
 }
-
 
 // Procedural functions
-if (! function_exists('dbg')) {
-	function dbg($state)
-	{
-		global $db;
-		$db->dbg($state);
-	}
+function dbg($state)
+{
+	global $db;
+	$db->dbg($state);
 }
 
-if (! function_exists('dbesc')) {
-	function dbesc($str)
-	{
-		global $db;
-		if ($db) {
-			return($db->escape($str));
-		}
+function dbesc($str)
+{
+	global $db;
+	if ($db) {
+		return($db->escape($str));
 	}
 }
-
 
 // Function: q($sql,$args);
 // Description: execute SQL query with printf style args.
 // Example: $r = q("SELECT * FROM `%s` WHERE `uid` = %d",
 //                   'user', 1);
 
-if (! function_exists('q')) {
-	function q($sql)
-	{
-		global $db;
-		$args = func_get_args();
-		unset($args[0]);
-		if ($db) {
-			$ret = $db->q(vsprintf($sql, $args));
-		}
+function q($sql)
+{
+	global $db;
+	$args = func_get_args();
+	unset($args[0]);
+
+	if ($db) {
+		$ret = $db->q(vsprintf($sql, $args));
+
 		if ($db->db->errno) {
 			logger('dba: ' . $db->db->error);
 		}
-
-
-		return $ret;
 	}
-}
 
+	return $ret;
+}
 
 // Caller is responsible for ensuring that any integer arguments to
 // dbesc_array are actually integers and not malformed strings containing
 // SQL injection vectors. All integer array elements should be specifically
 // cast to int to avoid trouble.
-
-
-if (! function_exists('dbesc_array_cb')) {
-	function dbesc_array_cb(&$item, $key)
-	{
-		if (is_string($item)) {
-			$item = dbesc($item);
-		}
+function dbesc_array_cb(&$item, $key)
+{
+	if (is_string($item)) {
+		$item = dbesc($item);
 	}
 }
 
-
-if (! function_exists('dbesc_array')) {
-	function dbesc_array(&$arr)
-	{
-		if (is_array($arr) && count($arr)) {
-			array_walk($arr, 'dbesc_array_cb');
-		}
+function dbesc_array(&$arr)
+{
+	if (is_array($arr) && count($arr)) {
+		array_walk($arr, 'dbesc_array_cb');
 	}
 }
 
-
-if (! function_exists('closedb')) {
-	function closedb()
-	{
-		global $db;
-//	$db->close();
-	}
+function closedb()
+{
+	global $db;
+	//	$db->close();
 }

--- a/include/dba.php
+++ b/include/dba.php
@@ -137,12 +137,16 @@ function q($sql)
 	$args = func_get_args();
 	unset($args[0]);
 
+	$ret = null;
+
 	if ($db) {
 		$ret = $db->q(vsprintf($sql, $args));
 
 		if ($db->db->errno) {
 			logger('dba: ' . $db->db->error);
 		}
+	} else {
+		error_log(__FILE__ . ':' . __LINE__ . ' $db has gone');
 	}
 
 	return $ret;

--- a/include/session.php
+++ b/include/session.php
@@ -1,68 +1,73 @@
 <?php
-
 // Session management functions. These provide database storage of PHP
 // session info.
 
 $session_exists = 0;
 $session_expire = 180000;
 
-if(! function_exists('ref_session_open')) { 
-function ref_session_open ($s,$n) {
-  return true;
-}}
+function ref_session_open($s, $n)
+{
+	return true;
+}
 
-if(! function_exists('ref_session_read')) { 
-function ref_session_read ($id) {
-  global $session_exists;
-  if(x($id))
-    $r = q("SELECT `data` FROM `session` WHERE `sid`= '%s'", dbesc($id));
-  if(count($r)) {
-    $session_exists = true;
-    return $r[0]['data'];
-  }
-  return '';
-}}
+function ref_session_read($id)
+{
+	global $session_exists;
 
-if(! function_exists('ref_session_write')) { 
-function ref_session_write ($id,$data) {
-  global $session_exists, $session_expire;
-  if(! $id || ! $data) { 
-    return false; 
-  }
+	if (x($id)) {
+		$r = q("SELECT `data` FROM `session` WHERE `sid`= '%s'", dbesc($id));
+	}
 
-  $expire = time() + $session_expire;
-  $default_expire = time() + 300;
+	if (count($r)) {
+		$session_exists = true;
+		return $r[0]['data'];
+	}
 
-  if($session_exists)
-    $r = q("UPDATE `session` 
-            SET `data` = '%s', `expire` = '%s' 
-            WHERE `sid` = '%s' LIMIT 1", 
-            dbesc($data), dbesc($expire), dbesc($id));
-  else
-    $r = q("INSERT INTO `session`
-            SET `sid` = '%s', `expire` = '%s', `data` = '%s'",
-            dbesc($id), dbesc($default_expire), dbesc($data));
+	return '';
+}
 
-  return true;
-}}
+function ref_session_write($id, $data)
+{
+	global $session_exists, $session_expire;
 
-if(! function_exists('ref_session_close')) { 
-function ref_session_close() {
-  return true;
-}}
+	if (!$id || !$data) {
+		return false;
+	}
 
-if(! function_exists('ref_session_destroy')) { 
-function ref_session_destroy ($id) {
-  q("DELETE FROM `session` WHERE `sid` = '%s'", dbesc($id));
-  return true;
-}}
+	$expire = time() + $session_expire;
+	$default_expire = time() + 300;
 
-if(! function_exists('ref_session_gc')) { 
-function ref_session_gc($expire) {
-  q("DELETE FROM `session` WHERE `expire` < %d", dbesc(time()));
-  q("OPTIMIZE TABLE `sess_data`");
-  return true;
-}}
+	if ($session_exists) {
+		$r = q("UPDATE `session`
+		SET `data` = '%s', `expire` = '%s'
+		WHERE `sid` = '%s' LIMIT 1", dbesc($data), dbesc($expire), dbesc($id));
+	} else {
+		$r = q("INSERT INTO `session`
+		SET `sid` = '%s', `expire` = '%s', `data` = '%s'", dbesc($id), dbesc($default_expire), dbesc($data));
+	}
+
+	return true;
+}
+
+function ref_session_close()
+{
+	return true;
+}
+
+function ref_session_destroy($id)
+{
+	q("DELETE FROM `session` WHERE `sid` = '%s'", dbesc($id));
+
+	return true;
+}
+
+function ref_session_gc($expire)
+{
+	q("DELETE FROM `session` WHERE `expire` < %d", dbesc(time()));
+	q("OPTIMIZE TABLE `sess_data`");
+	
+	return true;
+}
 
 $gc_probability = 50;
 
@@ -70,7 +75,11 @@ ini_set('session.gc_probability', $gc_probability);
 ini_set('session.use_only_cookies', 1);
 ini_set('session.cookie_httponly', 1);
 
-
-session_set_save_handler ('ref_session_open', 'ref_session_close',
-                            'ref_session_read', 'ref_session_write',
-                            'ref_session_destroy', 'ref_session_gc');
+session_set_save_handler(
+	'ref_session_open',
+	'ref_session_close',
+	'ref_session_read',
+	'ref_session_write',
+	'ref_session_destroy',
+	'ref_session_gc'
+);

--- a/index.php
+++ b/index.php
@@ -75,6 +75,8 @@ if ($a->module_loaded) {
 	if ((!$a->error) && (function_exists($a->module . '_content'))) {
 		$func = $a->module . '_content';
 		$a->page['content'] = $func($a);
+
+		killme();
 	}
 }
 
@@ -113,7 +115,4 @@ $template = 'view/'
 
 require_once $template;
 
-session_write_close();
-
-
-exit;
+killme();

--- a/index.php
+++ b/index.php
@@ -115,6 +115,5 @@ require_once $template;
 
 session_write_close();
 
-closedb();
 
 exit;

--- a/src/Rendering/View.php
+++ b/src/Rendering/View.php
@@ -9,7 +9,6 @@ use \Closure;
  */
 class View
 {
-        exit;
 	#TODO: Replace this with better code.
 
 	protected $layout;

--- a/src/Rendering/View.php
+++ b/src/Rendering/View.php
@@ -1,4 +1,6 @@
-<?php namespace Friendica\Directory\Rendering;
+<?php
+
+namespace Friendica\Directory\Rendering;
 
 use \Closure;
 
@@ -7,103 +9,98 @@ use \Closure;
  */
 class View
 {
-    
-    #TODO: Replace this with better code.
-    
-    public static function getViewPath($name)
-    {
-        return dirname(__DIR__).'/templates/view/'.$name.'.php';
-    }
-    
-    public static function getLayoutPath($name)
-    {
-        return dirname(__DIR__).'/templates/layout/'.$name.'.php';
-    }
-    
-    protected $layout;
-    protected $view;
-    protected $helpers;
-    
-    public function getHelpers(){
-      return $this->helpers;
-    }
-    
-    public function addHelper($name, Closure $helper)
-    {
-        $this->helpers[$name] = $helper;
-    }
-    
-    public function getView(){
-        return $this->view;
-    }
-
-    public function setView($value){
-        $this->view = $value;
-    }
-
-    public function getLayout(){
-        return $this->layout;
-    }
-
-    public function setLayout($value){
-        $this->layout = $value;
-    }
-
-    public function __construct($view=null, $layout="default")
-    {
-        
-        $this->view = $view;
-        $this->layout = $layout;
-        $this->helpers = array();
-        
-    }
-
-    public function render(array $data=array())
-    {
-        
-        //First the outer view.
-        $view = self::getViewPath($this->view);
-        $viewContent = $this->encapsulatedRequire($view, $data);
-        
-        //Then the layout, including the view as $content.
-        $data['content'] = $viewContent;
-        $layout = self::getLayoutPath($this->layout);
-        return $this->encapsulatedRequire($layout, $data);
-        
-    }
-    
-    public function output(array $data=array())
-    {
-        
-        header("Content-type: text/html; charset=utf-8");
-        echo $this->render($data);
         exit;
-        
-    }
-    
-    public function encapsulatedRequire($filename, array $data=null)
-    {
-        
-        //This will provide our variables on the global scope.
-        $call = function($__FILE__, $__VARS__){
-            extract($__VARS__, EXTR_SKIP);
-            require $__FILE__;
-        };
-        
-        //Use our current data as fallback.
-        if(!is_array($data)){
-            $data = $this->currentData;
-        }
-        
-        //This will add the helper class to $this.
-        $helpers = new ViewHelpers($this, $data);
-        $call = $call->bindTo($helpers, get_class($helpers));
-        
-        //Run and return the value.
-        ob_start();
-        $call($filename, $data);
-        return ob_get_clean();
-        
-    }
-    
+	#TODO: Replace this with better code.
+
+	protected $layout;
+	protected $view;
+	protected $helpers;
+
+	public static function getViewPath($name)
+	{
+		return dirname(__DIR__) . '/templates/view/' . $name . '.php';
+	}
+
+	public static function getLayoutPath($name)
+	{
+		return dirname(__DIR__) . '/templates/layout/' . $name . '.php';
+	}
+
+	public function getHelpers()
+	{
+		return $this->helpers;
+	}
+
+	public function addHelper($name, Closure $helper)
+	{
+		$this->helpers[$name] = $helper;
+	}
+
+	public function getView()
+	{
+		return $this->view;
+	}
+
+	public function setView($value)
+	{
+		$this->view = $value;
+	}
+
+	public function getLayout()
+	{
+		return $this->layout;
+	}
+
+	public function setLayout($value)
+	{
+		$this->layout = $value;
+	}
+
+	public function __construct($view = null, $layout = "default")
+	{
+		$this->view = $view;
+		$this->layout = $layout;
+		$this->helpers = array();
+	}
+
+	public function render(array $data = array())
+	{
+		//First the outer view.
+		$view = self::getViewPath($this->view);
+		$viewContent = $this->encapsulatedRequire($view, $data);
+
+		//Then the layout, including the view as $content.
+		$data['content'] = $viewContent;
+		$layout = self::getLayoutPath($this->layout);
+		return $this->encapsulatedRequire($layout, $data);
+	}
+
+	public function output(array $data = array())
+	{
+		header("Content-type: text/html; charset=utf-8");
+		echo $this->render($data);
+	}
+
+	public function encapsulatedRequire($filename, array $data = null)
+	{
+		//This will provide our variables on the global scope.
+		$call = function($__FILE__, $__VARS__) {
+			extract($__VARS__, EXTR_SKIP);
+			require $__FILE__;
+		};
+
+		//Use our current data as fallback.
+		if (!is_array($data)) {
+			$data = $this->currentData;
+		}
+
+		//This will add the helper class to $this.
+		$helpers = new ViewHelpers($this, $data);
+		$call = $call->bindTo($helpers, get_class($helpers));
+
+		//Run and return the value.
+		ob_start();
+		$call($filename, $data);
+		return ob_get_clean();
+	}
 }


### PR DESCRIPTION
This PR fixes the case where `exit;` was called before `session_write_close()`. The DB was already unloaded, and the session handler tried to write the session data to the DB.

Using `killme()` instead avoid this pitfall.